### PR TITLE
Add variable descriptions for posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,7 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="{{ site.twitter_username }}">
   <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
-  <meta name="twitter:description" content="{{ site.description }}">
+  <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 
   {% if page.socialImageSrc %}
     <meta name="twitter:image:src" content="{{ page.socialImageSrc | prepend: site.baseurl | prepend: site.url }}" />
@@ -30,7 +30,7 @@
   {% else %}
     <meta property="og:image" content="{{ site.socialImageSrcFacebook | prepend: site.baseurl | prepend: site.url }}" />
   {% endif %}
-  <meta property="og:description" content="{{ site.description }}" />
+  <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
 
   <title>{% if page.title %}{{ page.title }} &bull; {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <link rel="shortcut icon" href="{{ "/img/favicons/favicon.ico" | prepend: site.baseurl }}">

--- a/_posts/2017-09-03-this-week-in-rustfest-9-impl-days.md
+++ b/_posts/2017-09-03-this-week-in-rustfest-9-impl-days.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "This Week in RustFest 9: Impl Days"
+description: "Announcing Impl Days, a post-RustFest get-together and fun hackery in Zürich sponsored by Mozilla"
 authors:
   - hoverbear
 ---
@@ -9,7 +10,7 @@ Last TWIRF we teased a thing we were planning with Mozilla, this week we want to
 
 # Impl Days After the Conference
 
-Immediately following the conference, on October 2nd and 3rd, we're currently planning a nice get together with some folks from the community as well as the Rust Team. 
+Immediately following the conference, on October 2nd and 3rd, we're currently planning a nice get together with some folks from the community as well as the Rust Team.
 
 The topic of the get together will be to work on topics related to the [`impl` period](https://internals.rust-lang.org/t/announcing-the-impl-period-sep-18-dec-17/5676). It will be a great chance for you to work on things with your newfound (or old) friends. It will be "bring your own food" (or just go out for lunch), and while there will be some content organized by the Rust Team members present, most things will be ad-hoc. We're hoping to get somewhere in the ballpark of 40 people involved.
 


### PR DESCRIPTION
I noticed we have the default description on all blogposts in the Twitter cards, this should fix that and make them customizable. I've added a custom description for the last TWiRF.