### PR TITLE
Removed canonical tag as it messes up metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
   <meta name="description" content="{{ site.description }}">
   <meta name="keywords" content="{{ site.metaKeywords }}">
   <meta name="google-site-verification" content="{{ site.siteVerification }}" />
-  <link rel="canonical" href="{{ site.url }}">
+
   <!-- Social: Twitter -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="{{ site.twitter_username }}">


### PR DESCRIPTION
Hey, I had to get rid of the `<link rel="canonical">` tag. It's not essential, but in its current form it was messing up all the pages when scraped via Facebook, pointing it to the main page's metadata. This resulted in all URLs having shared had the default metadata.

Could fix this by fixing the canonical tag to point the proper canonical URL, but currently there's not a huge gain we could get out of it, easier is just to remove it for now.