### PR TITLE
Switch site.url to https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ email: team@rustfest.eu
 description: >
   A Community Rust conference for the Rusty folks all around Europe.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://blog.rustfest.eu" # the base hostname & protocol for your site
+url: "https://blog.rustfest.eu" # the base hostname & protocol for your site
 timezone: Europe/Zurich
 
 # Build settings


### PR DESCRIPTION
This should tell the social image bots to fetch our images via https.

Does anyone know if there are other side effects?

Cheers,
Stefan